### PR TITLE
🔧 fix: connect auto-fix issues to PR workflow

### DIFF
--- a/.github/workflows/opencode-auto-fix.yml
+++ b/.github/workflows/opencode-auto-fix.yml
@@ -84,8 +84,8 @@ jobs:
               --repo "${{ github.repository }}" \
               --state open \
               --limit 50 \
-              --json number \
-              --jq '.[].number'); do
+              --json number,labels \
+              --jq '.[] | select(([.labels[].name] | index("auto-fix-failed") | not) and ([.labels[].name] | index("auto-fix-pr-opened") | not)) | .number'); do
               HAS_PR=$(gh pr list \
                 --repo "${{ github.repository }}" \
                 --state open \
@@ -292,11 +292,31 @@ jobs:
             echo "pr_url=$PR_URL"
           } >> "$GITHUB_OUTPUT"
 
+          gh issue comment "${{ steps.context.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --body "OpenCode auto-fix PR: $PR_URL"
+          gh label create auto-fix-pr-opened \
+            --repo "${{ github.repository }}" \
+            --color 0E8A16 \
+            --description "An automated fix PR has been opened for this issue." \
+            --force >/dev/null 2>&1 || true
+          gh issue edit "${{ steps.context.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label auto-fix-pr-opened || true
+
       - name: Report auto-fix failure on issue
         if: failure() && steps.context.outputs.issue_number != ''
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
+          gh label create auto-fix-failed \
+            --repo "${{ github.repository }}" \
+            --color B60205 \
+            --description "Automated OpenCode fix failed before PR creation." \
+            --force >/dev/null 2>&1 || true
+          gh issue edit "${{ steps.context.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label auto-fix-failed || true
           {
             echo "OpenCode auto-fix failed before a PR could be created."
             echo

--- a/.github/workflows/sparkleforge-daily-roadmap.yml
+++ b/.github/workflows/sparkleforge-daily-roadmap.yml
@@ -42,7 +42,6 @@ jobs:
           set -euo pipefail
           python -m pip install --upgrade pip
           python -m pip install -e .
-          python -c "import aiosqlite" || python -m pip install aiosqlite
 
       - name: Prepare daily research prompt
         id: prompt
@@ -173,13 +172,8 @@ jobs:
           echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
           echo "created=true" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch OpenCode auto-fix workflow
+      - name: Report follow-up automation
         if: steps.create_issue.outputs.created == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run opencode-auto-fix.yml \
-            --repo "${{ github.repository }}" \
-            --ref main \
-            -f issue_number="${{ steps.create_issue.outputs.issue_number }}" \
-            -f max_iterations="${{ github.event.inputs.max_iterations || '3' }}"
+          echo "Issue #${{ steps.create_issue.outputs.issue_number }} was created."
+          echo "opencode-auto-fix.yml will process it via its scheduled backlog scan."


### PR DESCRIPTION
## Summary

- Stop the daily roadmap workflow from directly dispatching the auto-fix workflow with the workflow token.
- Let opencode-auto-fix mark issues once a PR is opened or when automated repair fails.
- Skip already-opened or failed auto-fix issues in scheduled backlog scans to avoid repeated issue churn.
- Remove the redundant ad-hoc aiosqlite install from the daily roadmap workflow.

Closes #11
Closes #68
Closes #71

## Validation

- ./actionlint .github/workflows/opencode-auto-fix.yml .github/workflows/auto-fix.yml .github/workflows/gemini-assistant.yml .github/workflows/sparkleforge-daily-roadmap.yml
- python -m compileall src/core/era_server_manager.py scripts/opencode_github_worker.py src/core/cli_agents/open_code_agent.py
