### PR TITLE
🔧 fix: harden daily roadmap MCP routing

### DIFF
--- a/.github/workflows/sparkleforge-daily-roadmap.yml
+++ b/.github/workflows/sparkleforge-daily-roadmap.yml
@@ -35,13 +35,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: pip
+
+      - uses: astral-sh/setup-uv@v5
 
       - name: Install SparkleForge
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip
-          python -m pip install -e .
+          uv sync
 
       - name: Prepare daily research prompt
         id: prompt
@@ -87,9 +87,11 @@ jobs:
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
           SPARKLEFORGE_CLI_INTERACTIVE: 'false'
+          MCP_BUILDER_ENABLED: 'false'
+          SPARKLEFORGE_ALLOWED_MCP_SERVERS: 'arxiv,fetch,sparkleforge-skills'
         run: |
           set +e
-          sparkleforge run "$(cat daily-roadmap-prompt.md)" \
+          uv run sparkleforge run "$(cat daily-roadmap-prompt.md)" \
             --output sparkleforge-roadmap.md \
             --format markdown \
             > sparkleforge-roadmap-console.log \

--- a/src/core/orchestrator/execution.py
+++ b/src/core/orchestrator/execution.py
@@ -269,7 +269,7 @@ class ExecutionNode(BaseNode):
         """카테고리별 사용 가능한 도구 목록을 반환합니다."""
         mapping = {
             ToolCategory.SEARCH: ["g-search", "ddg_search::search", "tavily-mcp::tavily-search"],
-            ToolCategory.ACADEMIC: ["semantic_scholar::papers-search-basic", "arxiv::arxiv_search"],
+            ToolCategory.ACADEMIC: ["arxiv", "scholar"],
             ToolCategory.DATA: ["fetch::fetch_url", "fetch::extract_elements"],
             ToolCategory.CODE: ["python_coder", "code_interpreter"],
             ToolCategory.BROWSER: ["cdp_navigate", "cdp_click", "cdp_type_text", "cdp_screenshot", "cdp_extract_text", "cdp_js", "cdp_page_info"],

--- a/src/core/orchestrator/execution.py
+++ b/src/core/orchestrator/execution.py
@@ -269,7 +269,7 @@ class ExecutionNode(BaseNode):
         """카테고리별 사용 가능한 도구 목록을 반환합니다."""
         mapping = {
             ToolCategory.SEARCH: ["g-search", "ddg_search::search", "tavily-mcp::tavily-search"],
-            ToolCategory.ACADEMIC: ["arxiv", "scholar"],
+            ToolCategory.ACADEMIC: ["arxiv"],
             ToolCategory.DATA: ["fetch::fetch_url", "fetch::extract_elements"],
             ToolCategory.CODE: ["python_coder", "code_interpreter"],
             ToolCategory.BROWSER: ["cdp_navigate", "cdp_click", "cdp_type_text", "cdp_screenshot", "cdp_extract_text", "cdp_js", "cdp_page_info"],

--- a/src/core/orchestrator/planning.py
+++ b/src/core/orchestrator/planning.py
@@ -13,6 +13,26 @@ from src.core.streaming_manager import EventType
 
 logger = logging.getLogger(__name__)
 
+def _extract_tool_result_items(result_data: Any) -> List[Any]:
+    """Return result items from common local/MCP tool payload shapes."""
+    if isinstance(result_data, list):
+        return result_data
+    if not isinstance(result_data, dict):
+        return []
+
+    for key in ("results", "items", "data"):
+        value = result_data.get(key)
+        if isinstance(value, list):
+            return value
+
+    value = result_data.get("result")
+    if isinstance(value, list):
+        return value
+    if value:
+        return [value]
+
+    return []
+
 class PlanningNode(BaseNode):
     """Handler for research planning and task decomposition."""
 
@@ -250,7 +270,7 @@ class PlanningNode(BaseNode):
                 )
                 if result.get("success", False):
                     result_data = result.get("data", {})
-                    data_list = result_data.get("results", []) if isinstance(result_data, dict) else (result_data if isinstance(result_data, list) else [])
+                    data_list = _extract_tool_result_items(result_data)
                     search_results.append({"keyword": keyword, "tool": tool_name, "data": data_list, "sources_count": len(data_list)})
             except Exception as e:
                 logger.warning(f"⚠️ {tool_name} search error: {e}")
@@ -265,7 +285,7 @@ class PlanningNode(BaseNode):
                 )
                 if result.get("success", False):
                     result_data = result.get("data", {})
-                    data_list = result_data.get("results", []) if isinstance(result_data, dict) else (result_data if isinstance(result_data, list) else [])
+                    data_list = _extract_tool_result_items(result_data)
                     academic_results.append({"tool": "arxiv", "data": data_list, "sources_count": len(data_list)})
             except Exception as e:
                 logger.warning(f"⚠️ academic search error: {e}")

--- a/src/core/orchestrator/planning.py
+++ b/src/core/orchestrator/planning.py
@@ -256,17 +256,19 @@ class PlanningNode(BaseNode):
                 logger.warning(f"⚠️ {tool_name} search error: {e}")
 
         academic_results = []
-        try:
-            result = await execute_tool(
-                tool_name="semantic_scholar::papers-search-basic",
-                parameters={"query": " ".join(keywords[:2]), "max_results": 3},
-            )
-            if result.get("success", False):
-                result_data = result.get("data", {})
-                data_list = result_data.get("results", []) if isinstance(result_data, dict) else (result_data if isinstance(result_data, list) else [])
-                academic_results.append({"tool": "semantic_scholar", "data": data_list, "sources_count": len(data_list)})
-        except Exception as e:
-            logger.warning(f"⚠️ academic search error: {e}")
+        academic_query = " ".join(keywords[:2])
+        if academic_query:
+            try:
+                result = await execute_tool(
+                    tool_name="arxiv",
+                    parameters={"query": academic_query, "max_results": 3},
+                )
+                if result.get("success", False):
+                    result_data = result.get("data", {})
+                    data_list = result_data.get("results", []) if isinstance(result_data, dict) else (result_data if isinstance(result_data, list) else [])
+                    academic_results.append({"tool": "arxiv", "data": data_list, "sources_count": len(data_list)})
+            except Exception as e:
+                logger.warning(f"⚠️ academic search error: {e}")
 
         return {
             "keywords": keywords,

--- a/tests/test_daily_roadmap_mcp_routing.py
+++ b/tests/test_daily_roadmap_mcp_routing.py
@@ -10,7 +10,7 @@ async def test_preliminary_research_uses_resilient_academic_tool(monkeypatch):
     async def fake_execute_tool(tool_name, parameters):
         calls.append((tool_name, parameters))
         if tool_name == "arxiv":
-            return {"success": True, "data": {"results": [{"title": "paper"}]}}
+            return {"success": True, "data": {"result": {"title": "paper"}}}
         return {"success": True, "data": {"results": []}}
 
     monkeypatch.setattr(

--- a/tests/test_daily_roadmap_mcp_routing.py
+++ b/tests/test_daily_roadmap_mcp_routing.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.core.orchestrator.planning import PlanningNode
+
+
+@pytest.mark.asyncio
+async def test_preliminary_research_uses_resilient_academic_tool(monkeypatch):
+    calls = []
+
+    async def fake_execute_tool(tool_name, parameters):
+        calls.append((tool_name, parameters))
+        if tool_name == "arxiv":
+            return {"success": True, "data": {"results": [{"title": "paper"}]}}
+        return {"success": True, "data": {"results": []}}
+
+    monkeypatch.setattr(
+        "src.core.orchestrator.planning.execute_tool",
+        fake_execute_tool,
+    )
+
+    node = PlanningNode(
+        context_manager=None,
+        context_loader=None,
+        research_depth="standard",
+        hybrid_storage=None,
+        streaming_manager=None,
+    )
+
+    result = await node._conduct_preliminary_research(
+        {
+            "analyzed_objectives": [
+                {"description": "current mcp agent automation research"}
+            ],
+            "domain_analysis": {"fields": ["github automation"]},
+        }
+    )
+
+    called_tools = [tool_name for tool_name, _ in calls]
+    assert "arxiv" in called_tools
+    assert "semantic_scholar::papers-search-basic" not in called_tools
+    assert result["academic_results"][0]["tool"] == "arxiv"


### PR DESCRIPTION
## Summary
- switch the daily roadmap workflow to uv setup/install/run
- prevent daily roadmap runs from auto-building missing MCP servers during research
- route preliminary academic research through the resilient arXiv path instead of the failing Semantic Scholar MCP server
- add a regression test so planning does not call semantic_scholar::papers-search-basic

## Validation
- uv run pytest tests/test_daily_roadmap_mcp_routing.py tests/test_mcp_param_normalization.py
- ./actionlint .github/workflows/sparkleforge-daily-roadmap.yml

Closes #76