### PR TITLE
🔧 fix: route failing MCP academic calls

### DIFF
--- a/.github/workflows/sparkleforge-daily-roadmap.yml
+++ b/.github/workflows/sparkleforge-daily-roadmap.yml
@@ -88,7 +88,9 @@ jobs:
           EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
           SPARKLEFORGE_CLI_INTERACTIVE: 'false'
           MCP_BUILDER_ENABLED: 'false'
-          SPARKLEFORGE_ALLOWED_MCP_SERVERS: 'arxiv,fetch,sparkleforge-skills'
+          MCP_ALLOWED_SERVERS: 'local-search,search,web-fetch,arxiv,sparkleforge-skills'
+          SPARKLEFORGE_ALLOWED_MCP_SERVERS: 'local-search,search,web-fetch,arxiv,sparkleforge-skills'
+          SPARKLEFORGE_SKIP_ERA_FOR_MCP: 'true'
         run: |
           set +e
           uv run sparkleforge run "$(cat daily-roadmap-prompt.md)" \

--- a/main.py
+++ b/main.py
@@ -2405,6 +2405,8 @@ async def handle_web_command(args):
 
 async def handle_mcp_command(args):
     """MCP 관리 커맨드 처리"""
+    os.environ.setdefault("SPARKLEFORGE_SKIP_ERA_FOR_MCP", "true")
+
     if args.mcp_command == "status":
         logger.info("🔍 Checking MCP server status...")
         mcp_hub = None
@@ -2476,6 +2478,7 @@ async def handle_health_command(args):
 
 async def handle_tools_command(args):
     """도구 관리 커맨드 처리"""
+    os.environ.setdefault("SPARKLEFORGE_SKIP_ERA_FOR_MCP", "true")
 
     def _default_tool_test_parameters(tool_name: str) -> Dict[str, Any]:
         """Return minimal non-destructive parameters for CLI tool smoke tests."""

--- a/src/core/mcp_integration.py
+++ b/src/core/mcp_integration.py
@@ -2352,7 +2352,12 @@ class UniversalMCPHub:
             return
 
         # ERA 서버 시작 (코드 실행을 위해)
-        if self.era_server_manager:
+        skip_era_for_mcp = os.getenv("SPARKLEFORGE_SKIP_ERA_FOR_MCP", "").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+        if self.era_server_manager and not skip_era_for_mcp:
             try:
                 if await self.era_server_manager.ensure_server_running():
                     logger.info(
@@ -2366,6 +2371,8 @@ class UniversalMCPHub:
                 logger.warning(
                     f"⚠️ Failed to start ERA server: {e} (code execution will use fallback)"
                 )
+        elif skip_era_for_mcp:
+            logger.info("[MCP][init] Skipping ERA startup for MCP-only command")
 
         try:
             logger.info("Initializing MCP Hub with MCP servers (no OpenRouter)...")
@@ -3298,6 +3305,29 @@ class UniversalMCPHub:
             parts = tool_name.split("::", 1)
             mcp_server = parts[0]
             mcp_tool_name = parts[1] if len(parts) > 1 else tool_name
+
+        semantic_scholar_aliases = (
+            "semantic_scholar::",
+            "semanticscholar::",
+            "semantic-scholar-mcp::",
+        )
+        if tool_name.startswith(semantic_scholar_aliases):
+            logger.warning(
+                "[MCP][semantic_scholar.disabled] Routing %s through arxiv fallback",
+                tool_name,
+            )
+            fallback_result = await self.execute_tool(
+                "arxiv",
+                parameters,
+                citation_id,
+                _skip_builder_retry=True,
+            )
+            fallback_result["source"] = "semantic_scholar_arxiv_fallback"
+            fallback_result.setdefault("metadata", {})
+            if isinstance(fallback_result["metadata"], dict):
+                fallback_result["metadata"]["requested_tool"] = tool_name
+                fallback_result["metadata"]["fallback_tool"] = "arxiv"
+            return fallback_result
 
         # Citation ID가 없으면 생성 (임시)
         if not citation_id:


### PR DESCRIPTION
## Summary
- route semantic_scholar::papers-search-basic and related aliases through the working arXiv MCP path instead of starting the rate-limited Semantic Scholar server
- skip ERA startup for MCP-only CLI commands so MCP smoke tests are not blocked by ERA health checks
- align daily roadmap MCP allowlist with the env var actually read by MCP initialization

## Verification
- uv run python -m py_compile main.py src/core/mcp_integration.py
- uv run pytest tests/test_daily_roadmap_mcp_routing.py tests/test_mcp_param_normalization.py
- ./actionlint .github/workflows/sparkleforge-daily-roadmap.yml
- timeout 120s uv run sparkleforge tools test semantic_scholar::papers-search-basic
- timeout 90s uv run sparkleforge mcp status --verbose

## Observed MCP smoke results
- local-search::search: returned success payload
- search::search: returned success payload
- web-fetch::fetch: fetched https://example.com with status 200
- arxiv::search: returned paper results
- context-mode::execute: returned stdout
- semantic_scholar::papers-search-basic: now succeeds through semantic_scholar_arxiv_fallback without Server error detected