### PR TITLE
🔧 fix: missing state persistence on cancellation in OpenRouter

### DIFF
--- a/src/core/orchestrator/execution.py
+++ b/src/core/orchestrator/execution.py
@@ -176,6 +176,9 @@ class ExecutionNode(BaseNode):
                         })
                 except Exception as e:
                     logger.error(f"Task execution error: {e}")
+                except asyncio.CancelledError:
+                    self._save_executions()
+                    raise
 
         # Depth Adjustment (Progressive Deepening)
         self._adjust_depth_if_needed(state, tasks, execution_results)


### PR DESCRIPTION
OpenCode-generated fix for https://github.com/ppijbb/sparkleforge/issues/101.

Closes #101

Source run: https://github.com/ppijbb/sparkleforge/actions/runs/25673903508