### PR TITLE
🔧 fix: ensure persistence of schedule executions on normal finish

### DIFF
--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -591,6 +591,7 @@ class Scheduler:
         try:
             await task
         except asyncio.CancelledError:
+            self._save_executions()
             execution.status = "cancelled"
             execution.completed_at = datetime.now()
         except Exception as e:


### PR DESCRIPTION
OpenCode-generated fix for https://github.com/ppijbb/sparkleforge/issues/128.

Closes #128

Source run: https://github.com/ppijbb/sparkleforge/actions/runs/25674739636