### PR TITLE
🔧 fix: 2026-06-03 - Daily roadmap generation timed out

### DIFF
--- a/.github/workflows/sparkleforge-daily-roadmap.yml
+++ b/.github/workflows/sparkleforge-daily-roadmap.yml
@@ -94,7 +94,7 @@ jobs:
           SPARKLEFORGE_SKIP_ERA_FOR_MCP: 'true'
         run: |
           set +e
-          timeout 25m uv run python -m src.cli.entry run "$(cat daily-roadmap-prompt.md)" \
+          timeout 25m uv run python -m src.cli.entry run "$(cat daily-roadmap-prompt.md)" --max-tokens 2048 \
             --output sparkleforge-roadmap.md \
             --format markdown \
             > sparkleforge-roadmap-console.log \


### PR DESCRIPTION
OpenCode-generated fix for https://github.com/ppijbb/sparkleforge/issues/178.

Refs #178

Source run: https://github.com/ppijbb/sparkleforge/actions/runs/26842799593