### PR TITLE
🔧 fix: 2026-06-12 - Daily roadmap CLI failed with exit code 1

### DIFF
--- a/.github/workflows/sparkleforge-daily-roadmap.yml
+++ b/.github/workflows/sparkleforge-daily-roadmap.yml
@@ -92,6 +92,7 @@ jobs:
           MCP_ALLOWED_SERVERS: 'local-search,search,web-fetch,arxiv,sparkleforge-skills'
           SPARKLEFORGE_ALLOWED_MCP_SERVERS: 'local-search,search,web-fetch,arxiv,sparkleforge-skills'
           SPARKLEFORGE_SKIP_ERA_FOR_MCP: 'true'
+          SPARKLEFORGE_ENV: 'production'
         run: |
           set +e
           timeout 25m uv run python -m src.cli.entry run --max-tokens 4096 \


### PR DESCRIPTION
OpenCode-generated fix for https://github.com/ppijbb/sparkleforge/issues/206.

Refs #206

Source run: https://github.com/ppijbb/sparkleforge/actions/runs/27368907555