### PR TITLE
🔧 fix: 2026-06-20 - Daily roadmap generation timed out

### DIFF
--- a/.github/workflows/sparkleforge-daily-roadmap.yml
+++ b/.github/workflows/sparkleforge-daily-roadmap.yml
@@ -95,7 +95,7 @@ jobs:
           SPARKLEFORGE_ENV: ${{ vars.SPARKLEFORGE_ENV || 'production' }}
         run: |
           set +e
-          timeout 25m uv run python -m src.cli.entry run --max-tokens 4096 \
+          timeout 25m uv run python -m src.cli.entry run --max-tokens 4096 --model google/gemini-2.0-flash-exp \
             --output sparkleforge-roadmap.md \
             --format markdown \
             < daily-roadmap-prompt.md > sparkleforge-roadmap-console.log \


### PR DESCRIPTION
OpenCode-generated fix for https://github.com/ppijbb/sparkleforge/issues/222.

Refs #222

Source run: https://github.com/ppijbb/sparkleforge/actions/runs/27840921944